### PR TITLE
fix: Allow implicit conversion of DateTimeValue types

### DIFF
--- a/OpenActive.NET/DateTimeValue.cs
+++ b/OpenActive.NET/DateTimeValue.cs
@@ -46,18 +46,18 @@ namespace OpenActive.NET
         }
         
 
-    /// <summary>
-    /// Gets the value of the current DateTimeValue object if it has been assigned an underlying value.
-    /// </summary>
-    public DateTimeOffset Value { get => NullableValue.Value; }
+        /// <summary>
+        /// Gets the value of the current DateTimeValue object if it has been assigned an underlying value.
+        /// </summary>
+        public DateTimeOffset Value { get => NullableValue.Value; }
 
         /// <summary>
-        /// Gets the value of the current DateTimeValue object as a Nullable<> type.
+        /// Gets the value of the underlying DateTimeOffset? object as a Nullable<> type.
         /// </summary>
         public DateTimeOffset? NullableValue { get; private set; }
 
         /// <summary>
-        /// Gets the value indicating whether the DateTimeValue object has a valid value of its underlying type
+        /// Gets the value indicating whether the DateTimeValue object has a valid value
         /// </summary>
         public bool HasValue { get => NullableValue.HasValue; }
 
@@ -78,7 +78,7 @@ namespace OpenActive.NET
         }
 
         /// <summary>
-        /// Gets a value indicating whether this instance has a value.
+        /// Indicating whether the value represents only a date (true) or a date with time (false).
         /// </summary>
         public bool IsDateOnly { get; set; }
 
@@ -135,7 +135,7 @@ namespace OpenActive.NET
         public override bool Equals(object obj) => obj is DateTimeValue ? this.Equals((DateTimeValue)obj) : false;
 
         /// <summary>
-        /// Implements ToString
+        /// Returns the value in "yyyy-MM-dd" format (if IsDateOnly) or "yyyy-MM-ddTHH:mm:sszzz" format otherwise
         /// </summary>
         /// <returns>
         /// A string representing the relevant value

--- a/OpenActive.NET/DateTimeValue.cs
+++ b/OpenActive.NET/DateTimeValue.cs
@@ -14,19 +14,20 @@ namespace OpenActive.NET
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateTimeValue"/> class.
+        /// If isDateOnly is true the time component of the supplied DateTimeOffset will be truncated.
         /// </summary>
         /// <param name="value">The value of property.</param>
         /// <param name="isDateOnly">Whether or not the value represents only a date.</param>
         public DateTimeValue(DateTimeOffset? value, bool isDateOnly)
         {
-            if (isDateOnly && value.HasValue && (value.Value.Hour != 0 || value.Value.Minute != 0 || value.Value.Second != 0 || value.Value.Millisecond != 0))
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), "Value must not include a time component if isDateOnly is used.");
-            }
-            this.NullableValue = value;
+            this.NullableValue = isDateOnly && value.HasValue ? new DateTimeOffset(value.Value.Year, value.Value.Month, value.Value.Day, 0, 0, 0, TimeSpan.Zero) : value;
             this.IsDateOnly = isDateOnly;
         }
 
+        /// <summary>
+        /// Attempts to parse a date or date/time value, setting the value of `isDateOnly` accordingly.
+        /// </summary>
+        /// <param name="value">An ISO 8601 date string.</param>
         public DateTimeValue(string value)
         {
             if (DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces, out var result))
@@ -94,7 +95,14 @@ namespace OpenActive.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator DateTimeValue(string item) => item.IsNullEmptyOrWhiteSpace() ? default : new DateTimeValue(new DateTimeOffset(DateTime.ParseExact(item, "yyyy-MM-dd", CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces)), true);
+        public static implicit operator DateTimeValue(string item) => item.IsNullEmptyOrWhiteSpace() ? default : new DateTimeValue(item);
+
+        /// <summary>
+        /// Performs an implicit conversion from DateTimeValue to DateTimeOffset.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator DateTimeOffset?(DateTimeValue item) => item.NullableValue;
 
         /// <summary>
         /// Implements the operator ==.

--- a/OpenActive.NET/DateValue.cs
+++ b/OpenActive.NET/DateValue.cs
@@ -14,15 +14,12 @@ namespace OpenActive.NET
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateValue"/> class.
+        /// The time component of the supplied DateTimeOffset will be truncated.
         /// </summary>
         /// <param name="value">The value of property.</param>
         public DateValue(DateTimeOffset? value)
         {
-            if (value.HasValue && (value.Value.Hour != 0 || value.Value.Minute != 0 || value.Value.Second != 0 || value.Value.Millisecond != 0))
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), "Value must not include a time component.");
-            }
-            this.NullableValue = value;
+            this.NullableValue = value.HasValue ? new DateTimeOffset(value.Value.Year, value.Value.Month, value.Value.Day, 0, 0, 0, TimeSpan.Zero) : value;
         }
 
         public DateValue(int year, int month, int day) : this(new DateTimeOffset(year, month, day, 0, 0, 0, new TimeSpan()))

--- a/OpenActive.NET/DateValue.cs
+++ b/OpenActive.NET/DateValue.cs
@@ -84,7 +84,14 @@ namespace OpenActive.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator DateValue(string item) => item.IsNullEmptyOrWhiteSpace() ? default : new DateValue(new DateTimeOffset(DateTime.ParseExact(item, "yyyy-MM-dd", CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces)));
+        public static implicit operator DateValue(string item) => item.IsNullEmptyOrWhiteSpace() ? default : new DateValue(item);
+
+        /// <summary>
+        /// Performs an implicit conversion from DateValue to DateTimeOffset.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator DateTimeOffset?(DateValue item) => item.NullableValue;
 
         /// <summary>
         /// Implements the operator ==.

--- a/OpenActive.NET/DateValue.cs
+++ b/OpenActive.NET/DateValue.cs
@@ -47,7 +47,7 @@ namespace OpenActive.NET
         public DateTimeOffset Value { get => NullableValue.Value; }
 
         /// <summary>
-        /// Gets the value of the current DateValue object as a Nullable<> type.
+        /// Gets the value of the underlying DateTimeOffset? object as a Nullable<> type.
         /// </summary>
         public DateTimeOffset? NullableValue { get; private set; }
 
@@ -125,7 +125,7 @@ namespace OpenActive.NET
         public override bool Equals(object obj) => obj is DateValue ? this.Equals((DateValue)obj) : false;
 
         /// <summary>
-        /// Implements ToString
+        /// Returns the value in "yyyy-MM-dd" format
         /// </summary>
         /// <returns>
         /// A string representing the relevant value

--- a/OpenActive.NET/TimeValue.cs
+++ b/OpenActive.NET/TimeValue.cs
@@ -56,7 +56,7 @@ namespace OpenActive.NET
         public DateTimeOffset Value { get => NullableValue.Value; }
 
         /// <summary>
-        /// Gets the value of the current TimeValue object as a Nullable<> type.
+        /// Gets the value of the underlying DateTimeOffset? object as a Nullable<> type.
         /// </summary>
         public DateTimeOffset? NullableValue { get; private set; }
 
@@ -134,7 +134,7 @@ namespace OpenActive.NET
         public override bool Equals(object obj) => obj is TimeValue ? this.Equals((TimeValue)obj) : false;
 
         /// <summary>
-        /// Implements ToString
+        /// Returns the value in "HH:mm" format
         /// </summary>
         /// <returns>
         /// A string representing the relevant value

--- a/OpenActive.NET/TimeValue.cs
+++ b/OpenActive.NET/TimeValue.cs
@@ -14,21 +14,24 @@ namespace OpenActive.NET
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeValue"/> class.
+        /// The date and timezone component of the supplied DateTimeOffset will be truncated.
         /// </summary>
         /// <param name="value">The value of property.</param>
         public TimeValue(DateTimeOffset? value)
         {
-            DateTimeOffset emptyDateTime = default;
-            if (value.HasValue && (value.Value.Year != emptyDateTime.Year || value.Value.Month != emptyDateTime.Month || value.Value.Day != emptyDateTime.Day || value.Value.Offset != emptyDateTime.Offset))
+            if (value.HasValue)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), "Value must not include date or offset components.");
+                this.NullableValue = new DateTimeOffset(1, 1, 1, value.Value.Hour, value.Value.Minute, 0, TimeSpan.Zero);
             }
-            this.NullableValue = value;
+            else
+            {
+                this.NullableValue = null;
+            }
         }
 
         public TimeValue(int hours, int minutes)
         {
-            DateTimeOffset dateTime = default;
+            DateTimeOffset dateTime = DateTimeOffset.MinValue;
             dateTime.AddHours(hours);
             dateTime.AddMinutes(minutes);
             this.NullableValue = dateTime;
@@ -54,6 +57,16 @@ namespace OpenActive.NET
         /// Gets the value of the current TimeValue object if it has been assigned an underlying value.
         /// </summary>
         public DateTimeOffset Value { get => NullableValue.Value; }
+
+        /// <summary>
+        /// Gets the value of Hour of the current TimeValue object if it has been assigned an underlying value.
+        /// </summary>
+        public int? Hour { get => NullableValue?.Hour; }
+
+        /// <summary>
+        /// Gets the value of Minute of the current TimeValue object if it has been assigned an underlying value.
+        /// </summary>
+        public int? Minute { get => NullableValue?.Minute; }
 
         /// <summary>
         /// Gets the value of the underlying DateTimeOffset? object as a Nullable<> type.
@@ -93,7 +106,7 @@ namespace OpenActive.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator TimeValue(string item) => item.IsNullEmptyOrWhiteSpace() ? default : new TimeValue(new DateTimeOffset(DateTime.ParseExact(item, "HH:mm", CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces)));
+        public static implicit operator TimeValue(string item) => item.IsNullEmptyOrWhiteSpace() ? default : new TimeValue(item);
 
         /// <summary>
         /// Implements the operator ==.


### PR DESCRIPTION
Allow implicit conversion of dates rather than throw errors at runtime